### PR TITLE
[JOSS review] Add tqdm to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyserial>=3.4
 setuptools>=38.4
 packaging
 numba>=0.51.2
+tqdm


### PR DESCRIPTION
Installing this in a fresh python environment, I encountered this missing dependency. I didn't pin a version as I have not tried which versions work and which don't, and the tqdm API has been fairly stable for a while.