### PR TITLE
Change numpy version requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/source/auto_examples
 docs/source/generated
 docs/source/api
 coverage.xml
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.18,<=1.23
+numpy>=1.18
 scipy>=1.3.0
 pandas>=0.24
 matplotlib>=3.0.2


### PR DESCRIPTION
Hello!

I was helping someone with a Python script they wrote using Systole. They kept running into dependency conflicts while trying to use the following packages:

- neurokit2 
- matplotlib
- numpy     
- pandas    
- bokeh     
- heartpy   
- scipy     
- sklearn   
- systole   
- bioread    

Some combination of these had Numpy dependencies during build and runtime that couldn't be resolved by pip. By removing the `<=1.23` constraint on Numpy in the `requirements.txt` file, this issue was resolved.

All of the Systole tests pass using Numpy version 1.24.4. I'm running Python version 3.10.4.

This is a small change so I just submitted a PR, but I'd be happy to open an Issue too if you'd like.